### PR TITLE
Fix error for non mandatory BCDStore parameter.

### DIFF
--- a/BCD/Helpers/BCDHelperFuncs.ps1
+++ b/BCD/Helpers/BCDHelperFuncs.ps1
@@ -48,24 +48,10 @@ Outputs one or more Windows boot applications in the form of BCD object instance
         [Parameter(ValueFromPipeline)]
         [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#ROOT/WMI/BcdStore')]
         [Microsoft.Management.Infrastructure.CimInstance]
-        $BCDStore
+        $BCDStore = (Get-BCDStore)
     )
 
-    $CimMethodArgs = @{}
-    $CimSessionComputerName = $BCDStore.GetCimSessionComputerName()
-
-    if ($CimSessionComputerName) { $CimMethodArgs['CimSession'] = Get-CimSession -InstanceId $BCDStore.GetCimSessionInstanceId() }
-
-    $BCDStoreToUse = $null
-
-    if ($BCDStore) {
-        $BCDStoreToUse = $BCDStore
-    } else {
-        # Use the system BCD store.
-        $BCDStoreToUse = Get-BCDStore @CimMethodArgs
-    }
-
-    Get-BCDObject -BCDStore $BCDStoreToUse -WellKnownId BootMgr
+    Get-BCDObject -BCDStore $BCDStore -WellKnownId BootMgr
 }
 
 function Get-BCDBootApplication {
@@ -130,27 +116,13 @@ Outputs one or more Windows boot applications in the form of BCD object instance
         [Parameter(ValueFromPipeline)]
         [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#ROOT/WMI/BcdStore')]
         [Microsoft.Management.Infrastructure.CimInstance]
-        $BCDStore
+        $BCDStore = (Get-BCDStore)
     )
 
-    $CimMethodArgs = @{}
-    $CimSessionComputerName = $BCDStore.GetCimSessionComputerName()
-
-    if ($CimSessionComputerName) { $CimMethodArgs['CimSession'] = Get-CimSession -InstanceId $BCDStore.GetCimSessionInstanceId() }
-
-    $BCDStoreToUse = $null
-
-    if ($BCDStore) {
-        $BCDStoreToUse = $BCDStore
-    } else {
-        # Use the system BCD store.
-        $BCDStoreToUse = Get-BCDStore @CimMethodArgs
-    }
-
     if ($Type) {
-        Get-BCDObject -BCDStore $BCDStoreToUse -WellKnownId $Type
+        Get-BCDObject -BCDStore $BCDStore -WellKnownId $Type
     } else {
-        Get-BCDObject -BCDStore $BCDStoreToUse -WellKnownId BootApp
+        Get-BCDObject -BCDStore $BCDStore -WellKnownId BootApp
     }
 }
 

--- a/BCD/UseCases/Debugging.ps1
+++ b/BCD/UseCases/Debugging.ps1
@@ -45,28 +45,12 @@ Outputs and object representing global debugger settings as well as the BCD obje
         [Parameter(ValueFromPipeline)]
         [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#ROOT/WMI/BcdStore')]
         [Microsoft.Management.Infrastructure.CimInstance]
-        $BCDStore
+        $BCDStore = (Get-BCDStore)
     )
 
-    $CimMethodArgs = @{}
-    $CimSessionComputerName = $BCDStore.GetCimSessionComputerName()
+    $PSComputerName=$BCDStore.PSComputerName
 
-    $PSComputerName = $null
-    if ($CimSessionComputerName) {
-        $CimMethodArgs['CimSession'] = Get-CimSession -InstanceId $BCDStore.GetCimSessionInstanceId()
-        $PSComputerName = $CimSession.ComputerName
-    }
-
-    $BCDStoreToUse = $null
-
-    if ($BCDStore) {
-        $BCDStoreToUse = $BCDStore
-    } else {
-        # Use the system BCD store.
-        $BCDStoreToUse = Get-BCDStore @CimMethodArgs
-    }
-
-    $DbgSettingsObject = Get-BCDObject -BCDStore $BCDStoreToUse -WellKnownId DbgSettings
+    $DbgSettingsObject = Get-BCDObject -BCDStore $BCDStore -WellKnownId DbgSettings
 
     $DebugType  = $null
     $DebugPort  = $null
@@ -129,8 +113,8 @@ Outputs and object representing global debugger settings as well as the BCD obje
         }[[Int]$DebugStartValue.Integer]
     }
 
-    $KernelDebuggerSet = Get-BCDObject -BCDStore $BCDStoreToUse | Get-BCDElement -Name KernelDebuggerEnabled
-    $BootDebugSet = Get-BCDObject -BCDStore $BCDStoreToUse | Get-BCDElement -Name BootDebug
+    $KernelDebuggerSet = Get-BCDObject -BCDStore $BCDStore | Get-BCDElement -Name KernelDebuggerEnabled
+    $BootDebugSet = Get-BCDObject -BCDStore $BCDStore | Get-BCDElement -Name BootDebug
 
     $KernelDebuggerEnabledObjects = $KernelDebuggerSet | Where-Object { $_.Boolean } | Select-Object -ExpandProperty ObjectId
     $KernelDebuggerDisabledObjects = $KernelDebuggerSet | Where-Object { -not $_.Boolean } | Select-Object -ExpandProperty ObjectId


### PR DESCRIPTION
The BCDStore parameter for Get-BCDBootApplication, Get-BCDBootManager, and Get-BCDDebugSettings was not mandatory but a method was called that required it to be set.

The code was removed in favor of setting a default value for the BCDstore parameter that achieves the same goal of getting the system BCD store if the parameter is unset.